### PR TITLE
Upload Custom .wav files, messages translated faster/properly now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(my_byte_speaker VERSION 1.0 DESCRIPTION "Byte Speaker" LANGUAGES CXX)
 
 # Compiler options (inherited by sub-folders)
 set(CMAKE_CXX_STANDARD 17)
-add_compile_options(-Wall -Werror -Wpedantic -Wextra)
+add_compile_options(-Wall -Werror -Wpedantic -Wextra -g)
 add_compile_options(-fdiagnostics-color)
 
 # Enable address sanitizer

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -29,6 +29,13 @@ COMMAND "${CMAKE_COMMAND}" -E copy_directory
    "~/cmpt433/public/myApps/beatbox-wav-files" 
 COMMENT "Copying WAVE files to public NFS directory")
 
+# Copy the WAV folder to NFS
+add_custom_command(TARGET byte_speaker POST_BUILD 
+COMMAND "${CMAKE_COMMAND}" -E copy_directory
+   "${CMAKE_SOURCE_DIR}/nodeServer"
+   "~/cmpt433/public/myApps/bytespeaker-server" 
+COMMENT "Copying nodeServer files to public NFS directory")
+
 # Copy the translator application to NFC
 add_custom_command(TARGET byte_speaker POST_BUILD 
 COMMAND "${CMAKE_COMMAND}" -E copy

--- a/app/include/network.hpp
+++ b/app/include/network.hpp
@@ -22,7 +22,8 @@ enum Command {
 };
 
 enum Mode {
-    CLINTAKE,
+    CL1_INTAKE,
+    CL2_INTAKE,
     NORMAL
 };
 

--- a/app/include/network.hpp
+++ b/app/include/network.hpp
@@ -16,6 +16,7 @@ enum Command {
     ESPEAK,
     CL1,
     CL2,
+    GET_INFO,
     SENDING_DATA,
     TERMINATE,
     UNKNOWN

--- a/app/include/network.hpp
+++ b/app/include/network.hpp
@@ -14,8 +14,16 @@
 
 enum Command {
     ESPEAK,
+    CL1,
+    CL2,
+    SENDING_DATA,
     TERMINATE,
     UNKNOWN
+};
+
+enum Mode {
+    CLINTAKE,
+    NORMAL
 };
 
 class Network {
@@ -32,10 +40,13 @@ private:
     Translator *translator;
     AudioMixer *audioMixer;
 
+    enum Mode mode = NORMAL;
+    int numPacketsLeft = 0;
+
     bool isRunning = false;
     void *networkThread(void *arg);
     enum Command checkCommand(char* input);
-    void sendReply(enum Command command, char *input, int socketDescriptor, struct sockaddr_in *sinRemote);
+    void sendReply(enum Command command, char *input, int length, int socketDescriptor, struct sockaddr_in *sinRemote);
 };
 
 #endif

--- a/app/include/translator.hpp
+++ b/app/include/translator.hpp
@@ -11,8 +11,11 @@ public:
     Translator();
     ~Translator();
     std::string translateToLanguage(std::string message , enum Language language);
+    void updateCurrentMessageTextFile(std::string message);
+    std::string getCurrentMessage();
 private:
     std::string runCommand(std::string command);
+    std::string currentMessage;
 };
 
 #endif

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -40,6 +40,8 @@ int main() {
         // std::this_thread::sleep_for(std::chrono::seconds(1));
         std::this_thread::sleep_for(std::chrono::seconds(3));
         audioMixer.queueSound(CUSTOM_1);
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+        audioMixer.queueSound(CUSTOM_2);
     }
 
     shutdownManager.waitForShutdown();

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -25,7 +25,7 @@ int main() {
     AudioMixer audioMixer(&languageManager);
     ShutdownManager shutdownManager;
     Network network(&shutdownManager, &languageManager, &textToSpeech, &translator, &audioMixer);
-    NFCReader reader("/dev/i2c-2", 0x24);
+    //NFCReader reader("/dev/i2c-2", 0x24);
 
     // Main loop
     while(!shutdownManager.isShutdown()) {
@@ -35,9 +35,11 @@ int main() {
         audioMixer.queueSound(FRENCH);
         std::this_thread::sleep_for(std::chrono::seconds(3));
         audioMixer.queueSound(GERMAN);
-        std::string uid = reader.waitForCardAndReadUID();
-        std::cout << "UID = " << uid << std::endl;
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+        // std::string uid = reader.waitForCardAndReadUID();
+        // std::cout << "UID = " << uid << std::endl;
+        // std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
+        audioMixer.queueSound(CUSTOM_1);
     }
 
     shutdownManager.waitForShutdown();

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -29,19 +29,19 @@ int main() {
 
     // Main loop
     while(!shutdownManager.isShutdown()) {
-        std::this_thread::sleep_for(std::chrono::seconds(3));
         audioMixer.queueSound(ENGLISH);
-        std::this_thread::sleep_for(std::chrono::seconds(3));
-        audioMixer.queueSound(FRENCH);
-        std::this_thread::sleep_for(std::chrono::seconds(3));
-        audioMixer.queueSound(GERMAN);
+        std::this_thread::sleep_for(std::chrono::seconds(20));
+        // std::this_thread::sleep_for(std::chrono::seconds(3));
+        // audioMixer.queueSound(FRENCH);
+        // std::this_thread::sleep_for(std::chrono::seconds(3));
+        // audioMixer.queueSound(GERMAN);
         // std::string uid = reader.waitForCardAndReadUID();
         // std::cout << "UID = " << uid << std::endl;
         // std::this_thread::sleep_for(std::chrono::seconds(1));
-        std::this_thread::sleep_for(std::chrono::seconds(3));
-        audioMixer.queueSound(CUSTOM_1);
-        std::this_thread::sleep_for(std::chrono::seconds(3));
-        audioMixer.queueSound(CUSTOM_2);
+        // std::this_thread::sleep_for(std::chrono::seconds(5));
+        // audioMixer.queueSound(CUSTOM_1);
+        // std::this_thread::sleep_for(std::chrono::seconds(5));
+        // audioMixer.queueSound(CUSTOM_2);
     }
 
     shutdownManager.waitForShutdown();

--- a/app/src/network.cpp
+++ b/app/src/network.cpp
@@ -44,7 +44,7 @@ Network::~Network() {
     networkThreadId.join();
 }
 
-#define MAX_LEN 200000
+#define MAX_LEN 65200
 #define PORT 12345
 void *Network::networkThread(void *arg) {
     (void)arg;

--- a/app/src/textToSpeech.cpp
+++ b/app/src/textToSpeech.cpp
@@ -59,7 +59,7 @@ void TextToSpeech::translateToWave(std::string message, enum Language language, 
             return;
     } 
     std::stringstream command;
-    command << "espeak '" << message << "' -v" << languageCode << " -w " << filename;
+    command << "espeak \"" << message << "\" -v" << languageCode << " -w " << filename;
 
     runCommand(command.str());
     // Allow 2 second for espeak processing, this should be more than enough

--- a/app/src/textToSpeech.cpp
+++ b/app/src/textToSpeech.cpp
@@ -52,16 +52,18 @@ void TextToSpeech::translateToWave(std::string message, enum Language language, 
         case GERMAN:
             languageCode = "de";
             break;
-        default:
+        case ENGLISH:
             languageCode = "en";
             break;
+        default:
+            return;
     } 
     std::stringstream command;
     command << "espeak '" << message << "' -v" << languageCode << " -w " << filename;
 
     runCommand(command.str());
     // Allow 2 second for espeak processing, this should be more than enough
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 }
 
 void TextToSpeech::runCommand(std::string command) {

--- a/app/src/translator.cpp
+++ b/app/src/translator.cpp
@@ -7,9 +7,19 @@
 #include <sstream>
 #include <thread>
 #include <chrono>
+#include <fstream>
 
 #define TRANSLATOR "./trans "
 Translator::Translator() {
+    std::ifstream file("currentMessage.txt");
+    if(file.good()) {
+        std::getline(file, currentMessage);
+    }
+    else {
+        std::ofstream newFile("currentMessage.txt");
+        newFile << "This is a default message";
+    }
+    file.close();
 }
 
 Translator::~Translator() {
@@ -28,8 +38,19 @@ std::string Translator::translateToLanguage(std::string message , enum Language 
             languageCode = "en";
             break;
     }
-    std::string command = std::string(TRANSLATOR) + "-b en:" + languageCode + " " + message;
+    std::string command = std::string(TRANSLATOR) + "-b en:" + languageCode + " \"" + message + "\"";
+    updateCurrentMessageTextFile(message);
     return runCommand(command);
+}
+
+void Translator::updateCurrentMessageTextFile(std::string message) {
+    currentMessage =  message;
+    std::ofstream file("currentMessage.txt");
+    file << message;
+    file.close();
+}
+std::string Translator::getCurrentMessage() { 
+    return currentMessage; 
 }
 
 std::string Translator::runCommand(std::string command) {

--- a/hal/include/hal/audioMixer.hpp
+++ b/hal/include/hal/audioMixer.hpp
@@ -66,6 +66,8 @@ private:
 	wavedata_t englishSound;
 	wavedata_t frenchSound;
 	wavedata_t germanSound;
+	wavedata_t custom1Sound;
+	wavedata_t custom2Sound;
 	playbackSound_t soundBite;
 
 	LanguageManager *languageManager;

--- a/hal/include/hal/languageManager.hpp
+++ b/hal/include/hal/languageManager.hpp
@@ -10,6 +10,8 @@ enum Language {
 	ENGLISH,
 	FRENCH,
 	GERMAN,
+	CUSTOM_1,
+	CUSTOM_2,
 };
 
 class LanguageManager {

--- a/hal/src/audioMixer.cpp
+++ b/hal/src/audioMixer.cpp
@@ -66,6 +66,12 @@ void AudioMixer::readWaveFileIntoMemory(std::string fileName, enum Language lang
 		case GERMAN:
 			fetchedSound = &germanSound;
 			break;
+		case CUSTOM_1:
+			fetchedSound = &custom1Sound;
+			break;
+		case CUSTOM_2:
+			fetchedSound = &custom2Sound;
+			break;
 		default:
 			fetchedSound = &englishSound;
 			break;
@@ -144,14 +150,24 @@ void AudioMixer::queueSound(enum Language language)
 		case GERMAN:
 			fetchedSound = &germanSound;
 			break;
+		case CUSTOM_1:
+			fetchedSound = &custom1Sound;
+			break;
+		case CUSTOM_2:
+			fetchedSound = &custom2Sound;
+			break;
 		default:
 			fetchedSound = &englishSound;
 			break;
 	}
 
 	// Ensure we are only being asked to play "good" sounds:
-	assert(fetchedSound->numSamples > 0);
-	assert(fetchedSound->pData);
+	if(fetchedSound->numSamples <= 0 || !fetchedSound->pData) {
+		std::cout << "ERROR: Sound file is empty or not loaded." << std::endl;
+		pthread_mutex_unlock(&audioMutex);
+		return;
+	}
+
         /*
         * Place the new sound file into that slot.
 	    * Note: You are only copying a pointer, not the entire data of the wave file!
@@ -183,6 +199,8 @@ AudioMixer::~AudioMixer() {
 	delete[] englishSound.pData;
 	delete[] frenchSound.pData;
 	delete[] germanSound.pData;
+	delete[] custom1Sound.pData;
+	delete[] custom2Sound.pData;
 
 	std::cout << "Done stopping audio..." << std::endl;
 	fflush(stdout);

--- a/hal/src/audioMixer.cpp
+++ b/hal/src/audioMixer.cpp
@@ -208,12 +208,18 @@ AudioMixer::~AudioMixer() {
 	delete[] playbackBuffer;
 	playbackBuffer = NULL;
 
-	// TODO: Free all sound here
+	// Free all sound here
 	delete[] englishSound.pData;
 	delete[] frenchSound.pData;
 	delete[] germanSound.pData;
-	delete[] custom1Sound.pData;
-	delete[] custom2Sound.pData;
+
+	// Custom sounds might not be loaded, so need to check for null before we free
+	if(custom1Sound.pData) {
+		delete[] custom1Sound.pData;
+	}
+	if(custom2Sound.pData) {
+		delete[] custom2Sound.pData;
+	}
 
 	std::cout << "Done stopping audio..." << std::endl;
 	fflush(stdout);

--- a/hal/src/audioMixer.cpp
+++ b/hal/src/audioMixer.cpp
@@ -48,6 +48,19 @@ AudioMixer::AudioMixer(LanguageManager *languageManagerReference) {
 	readWaveFileIntoMemory("beatbox-wav-files/french_msg.wav", FRENCH);
 	readWaveFileIntoMemory("beatbox-wav-files/german_msg.wav", GERMAN);
 
+	// Check for custom messages
+	std::string custom1Filename = languageManager->getWavFilename(CUSTOM_1);
+    std::ifstream custom1File(custom1Filename);
+    if(custom1File.good()) {
+		readWaveFileIntoMemory("beatbox-wav-files/custom1_msg.wav", CUSTOM_1);
+    }
+
+	std::string custom2Filename = languageManager->getWavFilename(CUSTOM_2);
+    std::ifstream custom2File(custom2Filename);
+    if(custom2File.good()) {
+		readWaveFileIntoMemory("beatbox-wav-files/custom2_msg.wav", CUSTOM_2);
+    }
+
 	// Launch playback thread:
 	playbackThreadId = std::thread([this]() {
         this->playbackThread(nullptr);

--- a/hal/src/languageManager.cpp
+++ b/hal/src/languageManager.cpp
@@ -7,6 +7,8 @@ LanguageManager::LanguageManager() {
 	audioFilenames.insert({ENGLISH, "beatbox-wav-files/english_msg.wav"});
 	audioFilenames.insert({FRENCH, "beatbox-wav-files/french_msg.wav"});
 	audioFilenames.insert({GERMAN, "beatbox-wav-files/german_msg.wav"});
+	audioFilenames.insert({CUSTOM_1, "beatbox-wav-files/custom1_msg.wav"});
+	audioFilenames.insert({CUSTOM_2, "beatbox-wav-files/custom2_msg.wav"});
 }
 
 LanguageManager::~LanguageManager() {

--- a/nodeServer/public/index.html
+++ b/nodeServer/public/index.html
@@ -18,8 +18,9 @@
 					<p>{Insert message here}</p>
 					<h3> Upload dictation </h3>
 					<p>Note: only .wav files accepted.</p>
-					<input type="file" name="file" accept=".wav"></br>
-					<input type="submit" id="btnUpload" value="Upload!" style="margin-top: 10px;" disabled/>
+					<input type="file" id="fileUpload" name="file" accept=".wav"></br>
+					<input type="submit" id="btnUpload1" value="Upload Custom Language 1" style="margin-top: 10px;"/>
+					<input type="submit" id="btnUpload2" value="Upload Custom Language 2" style="margin-top: 10px;"/>
 					<h3>Shutdown</h3>
 					<input type="button" id="btnTerminate" value="Terminate Program" style="margin-bottom: 10px;"/>
 				</div>

--- a/nodeServer/public/index.html
+++ b/nodeServer/public/index.html
@@ -15,7 +15,12 @@
 					<h3>Status</h3>
 					<p>Device 1 status: <b id="device-status">Online?</b></p> 
 					<h3>Current Message</h3>
-					<p>{Insert message here}</p>
+					<p id="current-message">Default</p>
+					<form id="msgForm">
+						<p><b>Update Current Message:</b></p>
+						<input type="text" id="new-message" placeholder="Please type the new English message here." required>
+						<button type="submit">Submit</button>  
+					</form>
 					<h3> Upload dictation </h3>
 					<p>Note: only .wav files accepted.</p>
 					<input type="file" id="fileUpload" name="file" accept=".wav"></br>

--- a/nodeServer/public/javascripts/admin_console_ui.js
+++ b/nodeServer/public/javascripts/admin_console_ui.js
@@ -25,11 +25,27 @@ $(document).ready(function() {
 			fileReader.onload = function(event) {
 				var fileData = event.target.result;
 				console.log("fileData size:", fileData.byteLength, "bytes");
-				sendFileViaUDP("cl1", fileData);
+				sendFileViaUDP("cl1 ", fileData);
 			};
 			fileReader.readAsArrayBuffer(file);
 		}
-	})
+	});
+
+	$('#btnUpload2').click(function() {
+		var file = document.getElementById('fileUpload').files[0];
+		console.log("File size:", file.size, "bytes");
+
+		if(file) {
+			console.log("File size:", file.size, "bytes");
+			var fileReader = new FileReader();
+			fileReader.onload = function(event) {
+				var fileData = event.target.result;
+				console.log("fileData size:", fileData.byteLength, "bytes");
+				sendFileViaUDP("cl2 ", fileData);
+			};
+			fileReader.readAsArrayBuffer(file);
+		}
+	});
 	
 });
 
@@ -45,9 +61,9 @@ function sendFileViaUDP(lang, fileData) {
 	console.log("fileData size:", fileData.byteLength, "bytes");
     console.log("Test " + lang);
     
-    // Emit the ArrayBuffer via socket
+    // Need to convert to base64, I can't seem to get the buffer to send correctly without it
 	var base64Data = btoa(String.fromCharCode.apply(null, new Uint8Array(fileData)));
-	socket.emit('fileUpload', 'cl1 ' + base64Data);
+	socket.emit('fileUpload', lang + base64Data);
 
 	var timeout = setTimeout(function() { 
 		var errMsg = "No response from back-end. Is NodeJS running on the target?";
@@ -55,7 +71,7 @@ function sendFileViaUDP(lang, fileData) {
 		$('#error-box').css("display", "block");
 	}, 10000);
 
-    socket.on('fileReply', function(result) {
+    socket.on('commandReply', function(result) {
 		clearTimeout(timeout);
     })
 };

--- a/nodeServer/public/javascripts/admin_console_ui.js
+++ b/nodeServer/public/javascripts/admin_console_ui.js
@@ -14,8 +14,51 @@ $(document).ready(function() {
 	$('#btnTerminate').click(function(){
 		sendCommandViaUDP("terminate");
 	});
+
+	$('#btnUpload1').click(function() {
+		var file = document.getElementById('fileUpload').files[0];
+		console.log("File size:", file.size, "bytes");
+
+		if(file) {
+			console.log("File size:", file.size, "bytes");
+			var fileReader = new FileReader();
+			fileReader.onload = function(event) {
+				var fileData = event.target.result;
+				console.log("fileData size:", fileData.byteLength, "bytes");
+				sendFileViaUDP("cl1", fileData);
+			};
+			fileReader.readAsArrayBuffer(file);
+		}
+	})
 	
 });
+
+// Add event listener for file input change
+$('#fileUpload').on('change', function() {
+	var btnUpload = $('#btnUpload1');
+	btnUpload.prop('disabled', !this.files[0]); // Disable the button if no file is selected
+	btnUpload = $('#btnUpload2');
+	btnUpload.prop('disabled', !this.files[0]); // Disable the button if no file is selected
+});
+
+function sendFileViaUDP(lang, fileData) {
+	console.log("fileData size:", fileData.byteLength, "bytes");
+    console.log("Test " + lang);
+    
+    // Emit the ArrayBuffer via socket
+	var base64Data = btoa(String.fromCharCode.apply(null, new Uint8Array(fileData)));
+	socket.emit('fileUpload', 'cl1 ' + base64Data);
+
+	var timeout = setTimeout(function() { 
+		var errMsg = "No response from back-end. Is NodeJS running on the target?";
+		$('#error-message').html(errMsg);
+		$('#error-box').css("display", "block");
+	}, 10000);
+
+    socket.on('fileReply', function(result) {
+		clearTimeout(timeout);
+    })
+};
 
 function sendCommandViaUDP(message) {
 	socket.emit('udpCommand', message);


### PR DESCRIPTION
Note, with longer messages AudioMixer returns -32 calling snd_pcm_writei, but snd_pcm_recover recovers it successfully. I do not know why this is and I think since it works we should just leave it.
I tested with an entire paragraph and it seems to work fine.